### PR TITLE
Update Gradle to 4.4 & bump compile/target SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ android:
     - tools
     - tools
     - platform-tools
-    - build-tools-26.0.0
-    - android-26
+    - build-tools-28.0.2
+    - android-28
     - android-22
     - sys-img-armeabi-v7a-android-22
 before_script:

--- a/DeviceAutomator/build.gradle
+++ b/DeviceAutomator/build.gradle
@@ -5,12 +5,12 @@ apply plugin: 'signing'
 version = '0.3.1-SNAPSHOT'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.0'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.2'
 
     defaultConfig {
         minSdkVersion 18
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 5
         versionName version
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,10 @@
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:3.1.4'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Mar 13 17:05:55 EDT 2017
+#Wed Sep 19 11:35:16 CDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
As we worked through updating various SDKs to use androidx instead of the previous support libraries, we ran into issues with device-automator also needing to be updated to prevent dependency conflicts we were hitting.  

This PR in preperation for androidx updates, updates only gradle, to a more current version.  It also bumps the compile & target SDK to 28 as well as the build tools, as a requirement for android x.