### PR TITLE
Support Android 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,12 @@ android:
     - tools
     - tools
     - platform-tools
-    - build-tools-29.0.2
-    - android-29
+    - build-tools-30.0.2
+    - android-30
     - android-22
     - sys-img-armeabi-v7a-android-22
+before_install:
+  - yes | sdkmanager "platforms;android-30"
 before_script:
   - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
   - emulator -avd test -skin WXGA720 -no-audio -no-window &

--- a/DeviceAutomator/build.gradle
+++ b/DeviceAutomator/build.gradle
@@ -17,6 +17,12 @@ android {
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+
     lintOptions {
         warning 'InvalidPackage'
         textReport true
@@ -26,14 +32,15 @@ android {
 
 dependencies {
     api 'androidx.test.uiautomator:uiautomator:2.2.0'
-    api 'androidx.test:runner:1.2.0'
-    api 'androidx.test:rules:1.2.0'
-    api 'androidx.core:core:1.1.0'
+    api 'androidx.test:runner:1.3.0'
+    api 'androidx.test:rules:1.3.0'
+    api 'androidx.core:core:1.3.1'
+    api 'androidx.test.ext:junit:1.1.2'
 
     androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
 
-    testImplementation 'org.robolectric:robolectric:3.8'
-    testImplementation 'org.mockito:mockito-core:2.8.47'
+    testImplementation 'org.robolectric:robolectric:4.3'
+    testImplementation 'org.mockito:mockito-core:2.28.2'
 }
 
 /* maven deploy + signing */

--- a/DeviceAutomator/build.gradle
+++ b/DeviceAutomator/build.gradle
@@ -5,12 +5,12 @@ apply plugin: 'signing'
 version = '1.0.0-SNAPSHOT'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion '29.0.2'
+    compileSdkVersion 30
+    buildToolsVersion '30.0.2'
 
     defaultConfig {
         minSdkVersion 18
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 6
         versionName version
 

--- a/DeviceAutomator/src/main/java/com/lukekorth/deviceautomator/DeviceAutomator.java
+++ b/DeviceAutomator/src/main/java/com/lukekorth/deviceautomator/DeviceAutomator.java
@@ -282,7 +282,7 @@ public class DeviceAutomator {
 
     private void clickPermissionDialogButton(String permission, int buttonIndex) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-                ContextCompat.checkSelfPermission(targetContext, permission) != PackageManager.PERMISSION_GRANTED) {
+                ContextCompat.checkSelfPermission(ApplicationProvider.getApplicationContext(), permission) != PackageManager.PERMISSION_GRANTED) {
             try {
                 UiObject allowPermissions = mDevice.findObject(new UiSelector()
                         .clickable(true)

--- a/DeviceAutomator/src/main/java/com/lukekorth/deviceautomator/DeviceAutomator.java
+++ b/DeviceAutomator/src/main/java/com/lukekorth/deviceautomator/DeviceAutomator.java
@@ -281,7 +281,6 @@ public class DeviceAutomator {
     }
 
     private void clickPermissionDialogButton(String permission, int buttonIndex) {
-        Context targetContext = ApplicationProvider.getApplicationContext();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
                 ContextCompat.checkSelfPermission(targetContext, permission) != PackageManager.PERMISSION_GRANTED) {
             try {

--- a/DeviceAutomator/src/main/java/com/lukekorth/deviceautomator/DeviceAutomator.java
+++ b/DeviceAutomator/src/main/java/com/lukekorth/deviceautomator/DeviceAutomator.java
@@ -122,7 +122,8 @@ public class DeviceAutomator {
      * @return {@link DeviceAutomator} for method chaining.
      */
     public DeviceAutomator launchApp(String packageName, long timeout) {
-        return launchApp(getInstrumentation().getContext().getPackageManager().getLaunchIntentForPackage(packageName), timeout);
+        Context targetContext = ApplicationProvider.getApplicationContext();
+        return launchApp(targetContext.getPackageManager().getLaunchIntentForPackage(packageName), timeout);
     }
 
     /**
@@ -145,7 +146,8 @@ public class DeviceAutomator {
     public DeviceAutomator launchApp(Intent intent, long timeout) {
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
-        getInstrumentation().getContext().startActivity(intent);
+        Context targetContext = ApplicationProvider.getApplicationContext();
+        targetContext.startActivity(intent);
 
         mDevice.wait(hasObject(By.pkg(intent.getPackage()).depth(0)), timeout);
 

--- a/DeviceAutomator/src/main/java/com/lukekorth/deviceautomator/DeviceAutomator.java
+++ b/DeviceAutomator/src/main/java/com/lukekorth/deviceautomator/DeviceAutomator.java
@@ -1,9 +1,12 @@
 package com.lukekorth.deviceautomator;
 
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.RemoteException;
+
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.uiautomator.By;
 import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject;
@@ -14,9 +17,7 @@ import androidx.core.content.ContextCompat;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 
-import static androidx.test.InstrumentationRegistry.getContext;
-import static androidx.test.InstrumentationRegistry.getInstrumentation;
-import static androidx.test.InstrumentationRegistry.getTargetContext;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static androidx.test.uiautomator.Until.hasObject;
 import static junit.framework.Assert.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -121,7 +122,7 @@ public class DeviceAutomator {
      * @return {@link DeviceAutomator} for method chaining.
      */
     public DeviceAutomator launchApp(String packageName, long timeout) {
-        return launchApp(getContext().getPackageManager().getLaunchIntentForPackage(packageName), timeout);
+        return launchApp(getInstrumentation().getContext().getPackageManager().getLaunchIntentForPackage(packageName), timeout);
     }
 
     /**
@@ -144,7 +145,7 @@ public class DeviceAutomator {
     public DeviceAutomator launchApp(Intent intent, long timeout) {
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
-        getContext().startActivity(intent);
+        getInstrumentation().getContext().startActivity(intent);
 
         mDevice.wait(hasObject(By.pkg(intent.getPackage()).depth(0)), timeout);
 
@@ -279,8 +280,9 @@ public class DeviceAutomator {
     }
 
     private void clickPermissionDialogButton(String permission, int buttonIndex) {
+        Context targetContext = ApplicationProvider.getApplicationContext();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-                ContextCompat.checkSelfPermission(getTargetContext(), permission) != PackageManager.PERMISSION_GRANTED) {
+                ContextCompat.checkSelfPermission(targetContext, permission) != PackageManager.PERMISSION_GRANTED) {
             try {
                 UiObject allowPermissions = mDevice.findObject(new UiSelector()
                         .clickable(true)

--- a/DeviceAutomator/src/main/java/com/lukekorth/deviceautomator/DeviceAutomator.java
+++ b/DeviceAutomator/src/main/java/com/lukekorth/deviceautomator/DeviceAutomator.java
@@ -146,8 +146,7 @@ public class DeviceAutomator {
     public DeviceAutomator launchApp(Intent intent, long timeout) {
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
-        Context targetContext = ApplicationProvider.getApplicationContext();
-        targetContext.startActivity(intent);
+        ApplicationProvider.getApplicationContext().startActivity(intent);
 
         mDevice.wait(hasObject(By.pkg(intent.getPackage()).depth(0)), timeout);
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.5.4'
     }
 }
 


### PR DESCRIPTION
## Support Android 11

- Update compileSdkVersion and targetSdkVersion to API level 30
- Use `ApplicationProvider` for accessing the target application context

## Authors
- @sarahkoop 
- @sshropshire 